### PR TITLE
ItemUtils.java and Utils.java can't be instantiated anymore.

### DIFF
--- a/src/main/java/net/cosmosmc/mcze/utils/ItemUtils.java
+++ b/src/main/java/net/cosmosmc/mcze/utils/ItemUtils.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 
 //We can use this for inventories and what not
 public class ItemUtils {
+    private ItemUtils() {}
 
     public static ItemStack createItem(Material material, String name, String... lore) {
         return createItem(material, name, 1, lore);

--- a/src/main/java/net/cosmosmc/mcze/utils/Utils.java
+++ b/src/main/java/net/cosmosmc/mcze/utils/Utils.java
@@ -3,6 +3,7 @@ package net.cosmosmc.mcze.utils;
 import org.bukkit.ChatColor;
 
 public class Utils {
+    private Utils() {}
 
     //Easier way of sending messages
     public static String color(String msg){


### PR DESCRIPTION
Because they're both utility classes and as far as I'm concerned only use static methods, they don't have to be instantiated.
