### PR TITLE
Close the INSERT prepared statement

### DIFF
--- a/src/main/java/net/cosmosmc/mcze/profiles/ProfileLoader.java
+++ b/src/main/java/net/cosmosmc/mcze/profiles/ProfileLoader.java
@@ -34,6 +34,7 @@ public class ProfileLoader extends BukkitRunnable {
             preparedStatement.setInt(6, 0);
             preparedStatement.setString(7, profile.getName());
             preparedStatement.execute();
+            preparedStatement.close();
 
             preparedStatement = connection.prepareStatement(SELECT);
             preparedStatement.setString(1, profile.getUuid().toString());


### PR DESCRIPTION
Really small commit :P. You close the prepared statement for selecting all the values, but that's after you reassign the variable "preparedStatement". Its old instance still needs to be closed, or else it will cause memory leaks (AFAIK).
